### PR TITLE
ロギング処理を追加

### DIFF
--- a/main.go
+++ b/main.go
@@ -3,7 +3,10 @@ package main
 import (
 	"context"
 	"log"
+	"log/slog"
 	"net/http"
+	"os"
+	"time"
 
 	"github.com/modelcontextprotocol/go-sdk/mcp"
 )
@@ -24,19 +27,97 @@ func SayHi(ctx context.Context, req *mcp.CallToolRequest, input Input) (
 	return nil, Output{Greeting: "Hi " + input.Name}, nil
 }
 
+type loggingResponseWriter struct {
+	http.ResponseWriter
+	status int
+}
+
+func (lrw *loggingResponseWriter) WriteHeader(code int) {
+	lrw.status = code
+	lrw.ResponseWriter.WriteHeader(code)
+}
+
+func loggingMiddleware(next http.Handler) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		start := time.Now()
+		lrw := &loggingResponseWriter{ResponseWriter: w, status: http.StatusOK}
+		next.ServeHTTP(lrw, r)
+
+		duration := time.Since(start)
+		log.Printf("%s %s from %s -> %d (%s)", r.Method, r.URL.Path, r.RemoteAddr, lrw.status, duration)
+	})
+}
+
 func main() {
+	logger := slog.New(slog.NewTextHandler(os.Stdout, &slog.HandlerOptions{
+		Level: slog.LevelInfo,
+	}))
+
 	// MCPサーバーを作成
 	server := mcp.NewServer(&mcp.Implementation{Name: "greeter", Version: "v1.0.0"}, nil)
 	mcp.AddTool(server, &mcp.Tool{Name: "greet", Description: "say hi"}, SayHi)
+
+	// MCPミドルウェアでリクエスト／レスポンスをログ出力
+	server.AddReceivingMiddleware(func(next mcp.MethodHandler) mcp.MethodHandler {
+		return func(ctx context.Context, method string, req mcp.Request) (mcp.Result, error) {
+			sessionID := ""
+			if session := req.GetSession(); session != nil {
+				sessionID = session.ID()
+			}
+
+			logger.Info("MCP method started",
+				"method", method,
+				"session_id", sessionID,
+				"has_params", req.GetParams() != nil,
+			)
+
+			if ctr, ok := req.(*mcp.CallToolRequest); ok {
+				logger.Info("Calling tool",
+					"name", ctr.Params.Name,
+					"args", ctr.Params.Arguments,
+				)
+			}
+
+			start := time.Now()
+			result, err := next(ctx, method, req)
+			duration := time.Since(start)
+
+			if err != nil {
+				logger.Error("MCP method failed",
+					"method", method,
+					"session_id", sessionID,
+					"duration_ms", duration.Milliseconds(),
+					"err", err,
+				)
+			} else {
+				logger.Info("MCP method completed",
+					"method", method,
+					"session_id", sessionID,
+					"duration_ms", duration.Milliseconds(),
+					"has_result", result != nil,
+				)
+				if ctr, ok := result.(*mcp.CallToolResult); ok {
+					logger.Info("tool result",
+						"isError", ctr.IsError,
+						"structuredContent", ctr.StructuredContent,
+					)
+				}
+			}
+
+			return result, err
+		}
+	})
 
 	// HTTPハンドラーを介してMCPリクエストを処理
 	handler := mcp.NewStreamableHTTPHandler(func(r *http.Request) *mcp.Server {
 		return server
 	}, nil)
 
+	loggedHandler := loggingMiddleware(handler)
+
 	const addr = ":8080"
 	log.Printf("MCP HTTP server listening on %s", addr)
-	if err := http.ListenAndServe(addr, handler); err != nil {
+	if err := http.ListenAndServe(addr, loggedHandler); err != nil {
 		log.Fatal(err)
 	}
 }


### PR DESCRIPTION
## リスタート手順
`docker build -t mcp-greeter .`
`docker run --rm -p 8080:8080 mcp-greeter`

## 動作確認

```sh
kyo.sato ~/go/src/github.com/Keyl0ve/mcp-migration-sample: % docker run --rm -p 8080:8080 mcp-greeter
2025/11/12 07:18:56 MCP HTTP server listening on :8080
2025/11/12 07:19:02 POST / from 192.168.65.1:49815 -> 200 (2.46225ms)
time=2025-11-12T07:19:02.807Z level=INFO msg="MCP method started" method=initialize session_id=3XXMTTX77WN7EGTJXI3GRGMGFQ has_params=true
time=2025-11-12T07:19:02.807Z level=INFO msg="MCP method completed" method=initialize session_id=3XXMTTX77WN7EGTJXI3GRGMGFQ duration_ms=0 has_result=true
time=2025-11-12T07:19:02.821Z level=INFO msg="MCP method started" method=notifications/initialized session_id=3XXMTTX77WN7EGTJXI3GRGMGFQ has_params=true
time=2025-11-12T07:19:02.821Z level=INFO msg="MCP method completed" method=notifications/initialized session_id=3XXMTTX77WN7EGTJXI3GRGMGFQ duration_ms=0 has_result=false
2025/11/12 07:19:02 POST / from 192.168.65.1:49815 -> 202 (64.833µs)
2025/11/12 07:19:02 POST / from 192.168.65.1:62785 -> 200 (436.167µs)
time=2025-11-12T07:19:02.825Z level=INFO msg="MCP method started" method=logging/setLevel session_id=3XXMTTX77WN7EGTJXI3GRGMGFQ has_params=true
time=2025-11-12T07:19:02.825Z level=INFO msg="MCP method completed" method=logging/setLevel session_id=3XXMTTX77WN7EGTJXI3GRGMGFQ duration_ms=0 has_result=true
time=2025-11-12T07:19:07.384Z level=INFO msg="MCP method started" method=tools/list session_id=3XXMTTX77WN7EGTJXI3GRGMGFQ has_params=true
time=2025-11-12T07:19:07.385Z level=INFO msg="MCP method completed" method=tools/list session_id=3XXMTTX77WN7EGTJXI3GRGMGFQ duration_ms=0 has_result=true
2025/11/12 07:19:07 POST / from 192.168.65.1:62785 -> 200 (1.72925ms)
time=2025-11-12T07:19:09.673Z level=INFO msg="MCP method started" method=tools/call session_id=3XXMTTX77WN7EGTJXI3GRGMGFQ has_params=true
time=2025-11-12T07:19:09.673Z level=INFO msg="Calling tool" name=greet args="{\"name\":\"aaa\"}"
time=2025-11-12T07:19:09.673Z level=INFO msg="MCP method completed" method=tools/call session_id=3XXMTTX77WN7EGTJXI3GRGMGFQ duration_ms=0 has_result=true
time=2025-11-12T07:19:09.673Z level=INFO msg="tool result" isError=false structuredContent="{\"greeting\":\"Hi aaa\"}"
2025/11/12 07:19:09 POST / from 192.168.65.1:62785 -> 200 (1.143916ms)
```